### PR TITLE
Added risk object to GET payment response

### DIFF
--- a/spec/definitions/Payments/Payment.yaml
+++ b/spec/definitions/Payments/Payment.yaml
@@ -67,11 +67,15 @@ properties:
     description: Provides information relating to the processing of 3D-Secure payments
     allOf:
       - $ref: '#/definitions/3dsData'
-  flagged:
-    type: boolean
-    description: Whether the payment was flagged by a risk check
-    default: false
-    example: true
+  risk:
+    type: object
+    description: Returns the payments risk assessment results
+    properties:
+      flagged:
+        type: boolean
+        description: Whether the payment was flagged by a risk check
+        default: false
+        example: true
   customer:
     type: object
     description: The customer to which this payment is linked


### PR DESCRIPTION
There was previously an inconsistency with the payment responses for creating the payment and getting it later.

Now both responses contain a risk object.