### PR TITLE
Payment response statuses updated

### DIFF
--- a/spec/components/schemas/Payments/PaymentResponse.yaml
+++ b/spec/components/schemas/Payments/PaymentResponse.yaml
@@ -39,16 +39,11 @@ properties:
     type: string
     description: The status of the payment
     enum:
-      - Pending
       - Authorized
+      - Pending
       - Card Verified
-      - Voided
-      - Partially Captured
       - Captured
-      - Partially Refunded
-      - Refunded
       - Declined
-      - Cancelled
     example: Authorized
   auth_code:
     type: string


### PR DESCRIPTION
The response `status` enumeration strings have been updated to reflect actual values applicable in the payment response (payment, card verification, payouts)